### PR TITLE
Settings: Add a DEVICE field to the getSummary() function

### DIFF
--- a/src/com/android/settings/deviceinfo/hardwareinfo/MarketNamePreferenceController.java
+++ b/src/com/android/settings/deviceinfo/hardwareinfo/MarketNamePreferenceController.java
@@ -48,6 +48,6 @@ public class MarketNamePreferenceController extends BasePreferenceController {
 
     @Override
     public CharSequence getSummary() {
-        return SystemProperties.get("ro.product.marketname");
+        return SystemProperties.get("ro.product.marketname", Build.DEVICE);
     }
 }


### PR DESCRIPTION
Missing this field results in the text string "Market Name" being displayed instead of the device name.